### PR TITLE
add resources

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,4 +4,15 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint'],
   root: true,
+  rules: {
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          '{}': false,
+        },
+        extendDefaults: true,
+      },
+    ],
+  },
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.tsbuildinfo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",
     "lodash": "^4.17.21",
+    "p-defer": "^4.0.0",
     "prettier": "^2.7.1",
     "typescript": "^4.9.3",
     "vitest": "^0.25.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ specifiers:
   eslint: ^8.28.0
   eslint-config-prettier: ^8.5.0
   lodash: ^4.17.21
+  p-defer: ^4.0.0
   prettier: ^2.7.1
   typescript: ^4.9.3
   vitest: ^0.25.2
@@ -20,6 +21,7 @@ devDependencies:
   eslint: 8.28.0
   eslint-config-prettier: 8.5.0_eslint@8.28.0
   lodash: 4.17.21
+  p-defer: 4.0.0
   prettier: 2.7.1
   typescript: 4.9.3
   vitest: 0.25.2
@@ -1086,6 +1088,11 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.3
+    dev: true
+
+  /p-defer/4.0.0:
+    resolution: {integrity: sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /p-limit/3.1.0:

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -1,7 +1,6 @@
-import type { Derived } from './derived';
 import { MANAGER } from './manager';
-import type { Signal } from './signal';
 import { getMax, Tag } from './tag';
+import type { ReactiveValue } from './types';
 
 type ComputeFn = () => void | (() => void);
 
@@ -9,10 +8,14 @@ export class Effect {
   #computeFn: ComputeFn;
   #version: number;
   #prevTags?: Array<Tag>;
-  #deps?: Array<Signal<unknown> | Derived<unknown>> | undefined;
+  // I would like to *not* use `any` here, but it could *actually* be anything so i'm not sure
+  // if there's a better option
+  // TODO: use something better than any here
+  #deps?: Array<ReactiveValue<any>> | undefined;
   #cleanupFn?: () => void;
 
-  constructor(fn: ComputeFn, deps?: Array<Signal<unknown> | Derived<unknown>>) {
+  // TODO: use something better than any here
+  constructor(fn: ComputeFn, deps?: Array<ReactiveValue<any>>) {
     this.#computeFn = fn;
     this.#version = MANAGER.version;
     this.#deps = deps;
@@ -70,10 +73,8 @@ export class Effect {
   }
 }
 
-export function createEffect(
-  fn: () => void,
-  deps?: Array<Signal<unknown> | Derived<unknown>>
-): () => boolean {
+// TODO: use something better than any here
+export function createEffect(fn: () => void, deps?: Array<ReactiveValue<any>>): () => boolean {
   const effect = new Effect(fn, deps);
   return effect.dispose.bind(effect);
 }

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -8,14 +8,10 @@ export class Effect {
   #computeFn: ComputeFn;
   #version: number;
   #prevTags?: Array<Tag>;
-  // I would like to *not* use `any` here, but it could *actually* be anything so i'm not sure
-  // if there's a better option
-  // TODO: use something better than any here
-  #deps?: Array<ReactiveValue<any>> | undefined;
+  #deps?: Array<ReactiveValue<unknown>> | undefined;
   #cleanupFn?: () => void;
 
-  // TODO: use something better than any here
-  constructor(fn: ComputeFn, deps?: Array<ReactiveValue<any>>) {
+  constructor(fn: ComputeFn, deps?: Array<ReactiveValue<unknown>>) {
     this.#computeFn = fn;
     this.#version = MANAGER.version;
     this.#deps = deps;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { createSignal, type Signal } from './signal';
 export { createDerived, type Derived } from './derived';
 export { createEffect, type Effect } from './effect';
+export { createResource, type Resource, type ResourceWithSignal } from './resource';
 export { TrackedSet } from './collections/tracked-set';

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,4 +1,3 @@
-import type { Derived } from './derived';
 import { createEffect } from './effect';
 import { createSignal, type Signal } from './signal';
 import { createTag, markDependency, markUpdate, type Tag } from './tag';
@@ -11,7 +10,7 @@ class Resource<ValueType> {
   private fetcher: Fetcher<ValueType>;
   private tag: Tag;
   loading = createSignal(false);
-  error?: unknown;
+  error: Signal<any> = createSignal();
 
   last?: ValueType | undefined;
 
@@ -32,8 +31,8 @@ class Resource<ValueType> {
       this.last = this.current;
       this.current = await this.fetcher(true);
       markUpdate(this.tag);
-    } catch (err) {
-      this.error = err;
+    } catch (err: any) {
+      this.error.value = err;
     } finally {
       this.loading.value = false;
     }
@@ -50,7 +49,7 @@ class ResourceWithSignal<ValueType, SourceType> {
   private source: ReactiveValue<SourceType>;
   private tag: Tag;
   loading = createSignal(false);
-  error?: unknown;
+  error: Signal<any> = createSignal();
 
   last?: ValueType | undefined;
 
@@ -80,7 +79,7 @@ class ResourceWithSignal<ValueType, SourceType> {
       this.current = await this.fetcher(source);
       markUpdate(this.tag);
     } catch (err) {
-      this.error = err;
+      this.error.value = err;
     } finally {
       this.loading.value = false;
     }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -6,7 +6,7 @@ import type { ReactiveValue } from './types';
 type Fetcher<ValueType> = (source: true) => Promise<ValueType>;
 type FetcherWithSource<SourceType, ValueType> = (source: SourceType) => Promise<ValueType>;
 
-class Resource<ValueType> {
+export class Resource<ValueType> {
   private fetcher: Fetcher<ValueType>;
   private tag: Tag;
   loading = createSignal(false);
@@ -44,7 +44,7 @@ class Resource<ValueType> {
   }
 }
 
-class ResourceWithSignal<ValueType, SourceType> {
+export class ResourceWithSignal<ValueType, SourceType> {
   private fetcher: FetcherWithSource<SourceType, ValueType>;
   private source: ReactiveValue<SourceType>;
   private tag: Tag;

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,0 +1,108 @@
+import type { Derived } from './derived';
+import { createEffect } from './effect';
+import { createSignal, type Signal } from './signal';
+import { createTag, markDependency, markUpdate, type Tag } from './tag';
+import type { ReactiveValue } from './types';
+
+type Fetcher<ValueType> = (source: true) => Promise<ValueType>;
+type FetcherWithSource<SourceType, ValueType> = (source: SourceType) => Promise<ValueType>;
+
+class Resource<ValueType> {
+  private fetcher: Fetcher<ValueType>;
+  private tag: Tag;
+  loading = createSignal(false);
+  error?: unknown;
+
+  last?: ValueType | undefined;
+
+  current?: ValueType | undefined;
+
+  constructor(fetcher: Fetcher<ValueType>) {
+    this.fetcher = fetcher;
+
+    this.tag = createTag();
+
+    this.fetch();
+  }
+
+  private async fetch() {
+    this.loading.value = true;
+
+    try {
+      this.last = this.current;
+      this.current = await this.fetcher(true);
+      markUpdate(this.tag);
+    } catch (err) {
+      this.error = err;
+    } finally {
+      this.loading.value = false;
+    }
+  }
+
+  get value() {
+    markDependency(this.tag);
+    return this.current;
+  }
+}
+
+class ResourceWithSignal<ValueType, SourceType> {
+  private fetcher: FetcherWithSource<SourceType, ValueType>;
+  private source: ReactiveValue<SourceType>;
+  private tag: Tag;
+  loading = createSignal(false);
+  error?: unknown;
+
+  last?: ValueType | undefined;
+
+  current?: ValueType | undefined;
+
+  constructor(
+    source: ReactiveValue<SourceType>,
+    fetcher: FetcherWithSource<SourceType, ValueType>
+  ) {
+    this.fetcher = fetcher;
+    this.source = source;
+    this.tag = createTag();
+    createEffect(() => {
+      this.fetch(this.source.value);
+    }, [this.source]);
+  }
+
+  private async fetch(source: SourceType) {
+    this.loading.value = true;
+
+    try {
+      this.last = this.current;
+      this.current = await this.fetcher(source);
+      markUpdate(this.tag);
+    } catch (err) {
+      this.error = err;
+    } finally {
+      this.loading.value = false;
+    }
+  }
+
+  get value() {
+    markDependency(this.tag);
+    return this.current;
+  }
+}
+
+export function createResource<ValueType>(fetcher: Fetcher<ValueType>): Resource<ValueType>;
+export function createResource<ValueType, SourceType>(
+  source: ReactiveValue<SourceType>,
+  fetcher: FetcherWithSource<SourceType, ValueType>
+): ResourceWithSignal<ValueType, SourceType>;
+export function createResource<ValueType, SourceType>(
+  sourceOrFetcher: ReactiveValue<SourceType> | Fetcher<ValueType>,
+  fetcher?: FetcherWithSource<SourceType, ValueType>
+): ResourceWithSignal<ValueType, SourceType> | Resource<ValueType> {
+  if (typeof sourceOrFetcher === 'function') {
+    return new Resource<ValueType>(sourceOrFetcher);
+  } else {
+    if (!fetcher || !(typeof fetcher === 'function')) {
+      throw new Error('You must pass a fetcher function when creating a Resource.');
+    }
+    return new ResourceWithSignal<ValueType, SourceType>(sourceOrFetcher, fetcher);
+  }
+}

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,40 +1,88 @@
 import { createEffect } from './effect';
-import { createSignal, type Signal } from './signal';
-import { createTag, markDependency, markUpdate, type Tag } from './tag';
+import { createSignal } from './signal';
+import { createTag, markDependency, markUpdate } from './tag';
 import type { ReactiveValue } from './types';
 
 type Fetcher<ValueType> = (source: true) => Promise<ValueType>;
 type FetcherWithSource<SourceType, ValueType> = (source: SourceType) => Promise<ValueType>;
 
+// These effectively do what `const enum` does, but doing it manually so we are not coupled to
+// use `tsc` itself to build them. Additionally, though, we only allocate a single array per
+// `Resource`, and reuse its memory when transitioning states. It would be nice if we could
+// make *that* operation safe, but at least this way it is isolated to these "constructors"
+// and the usage can be type safe.
+const INITIAL_TAG = 0;
+const LOADING_TAG = 1;
+const LOADED_TAG = 2;
+const ERROR_TAG = 3;
+
+type Initial = [typeof INITIAL_TAG];
+const Initial = (): Initial => [INITIAL_TAG];
+
+type Loading = [typeof LOADING_TAG];
+const Loading = <T>(state: State<T>): Loading => {
+  state[0] = LOADING_TAG;
+  state[1] = undefined;
+  return state as Loading;
+};
+
+type Loaded<T> = [typeof LOADED_TAG, T];
+const Loaded = <T>(state: State<T>, value: T): Loaded<T> => {
+  state[0] = LOADED_TAG;
+  state[1] = value;
+  return state as Loaded<T>;
+};
+
+type Failed = [typeof ERROR_TAG, unknown];
+const Failed = <T>(state: State<T>, err: unknown): Failed => {
+  state[0] = ERROR_TAG;
+  state[1] = err;
+  return state as Failed;
+};
+
+type State<T> = Initial | Loading | Loaded<T> | Failed;
+
 export class Resource<ValueType> {
   private fetcher: Fetcher<ValueType>;
-  private tag: Tag;
-  loading = createSignal(false);
-  error: Signal<any> = createSignal();
+  private tag = createTag();
+  private state = createSignal<State<ValueType>>(
+    Initial(),
+    ([oldState], [newState]) => oldState !== newState
+  );
+
+  get loading(): boolean {
+    return this.state.value[0] === LOADING_TAG;
+  }
+
+  get error(): unknown {
+    // The check is important so we never return the value for a loaded case!
+    return this.state.value[0] === ERROR_TAG ? this.state.value[1] : undefined;
+  }
 
   last?: ValueType | undefined;
 
-  current?: ValueType | undefined;
+  get current(): ValueType | undefined {
+    return this.state.value[0] === LOADED_TAG ? this.state.value[1] : undefined;
+  }
 
   constructor(fetcher: Fetcher<ValueType>) {
     this.fetcher = fetcher;
-
-    this.tag = createTag();
-
     this.fetch();
   }
 
   private async fetch() {
-    this.loading.value = true;
+    this.state.value = Loading(this.state.value);
 
     try {
+      // We always want to go ahead and update the previous state, so that we always end up
+      // with both the previous result (if any) *and* the new value *or* error, and never
+      // end up just throwing away data.
       this.last = this.current;
-      this.current = await this.fetcher(true);
+      const value = await this.fetcher(true);
+      this.state.value = Loaded(this.state.value, value);
       markUpdate(this.tag);
-    } catch (err: any) {
-      this.error.value = err;
-    } finally {
-      this.loading.value = false;
+    } catch (err: unknown) {
+      this.state.value = Failed(this.state.value, err);
     }
   }
 
@@ -46,42 +94,55 @@ export class Resource<ValueType> {
 
 export class ResourceWithSignal<ValueType, SourceType> {
   private fetcher: FetcherWithSource<SourceType, ValueType>;
-  private source: ReactiveValue<SourceType>;
-  private tag: Tag;
-  loading = createSignal(false);
-  error: Signal<any> = createSignal();
+  private tag = createTag();
+  private state = createSignal<State<ValueType>>(
+    Initial(),
+    ([oldState], [newState]) => oldState !== newState
+  );
+
+  get loading(): boolean {
+    return this.state.value[0] === LOADING_TAG;
+  }
+
+  get error(): unknown {
+    // The check is important so we never return the value for a loaded case!
+    return this.state.value[0] === ERROR_TAG ? this.state.value[1] : undefined;
+  }
 
   last?: ValueType | undefined;
 
-  current?: ValueType | undefined;
+  get current(): ValueType | undefined {
+    return this.state.value[0] === LOADED_TAG ? this.state.value[1] : undefined;
+  }
 
   constructor(
     source: ReactiveValue<SourceType>,
     fetcher: FetcherWithSource<SourceType, ValueType>
   ) {
     this.fetcher = fetcher;
-    this.source = source;
-    this.tag = createTag();
     createEffect(() => {
-      const value = this.source.value;
+      const value = source.value;
       if (value === false || value === null || value === undefined) {
+        console.log('bail!');
         return;
       }
       this.fetch(value);
-    }, [this.source]);
+    }, [source]);
   }
 
   private async fetch(source: SourceType) {
-    this.loading.value = true;
+    this.state.value = Loading(this.state.value);
 
     try {
+      // We always want to go ahead and update the previous state, so that we always end up
+      // with both the previous result (if any) *and* the new value *or* error, and never
+      // end up just throwing away data.
       this.last = this.current;
-      this.current = await this.fetcher(source);
+      const value = await this.fetcher(source);
+      this.state.value = Loaded(this.state.value, value);
       markUpdate(this.tag);
     } catch (err) {
-      this.error.value = err;
-    } finally {
-      this.loading.value = false;
+      this.state.value = Failed(this.state.value, err);
     }
   }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,69 +1,20 @@
 import { createEffect } from './effect';
-import { createSignal } from './signal';
+import { createSignal, Signal } from './signal';
 import { createTag, markDependency, markUpdate } from './tag';
 import type { ReactiveValue } from './types';
 
 type Fetcher<ValueType> = (source: true) => Promise<ValueType>;
 type FetcherWithSource<SourceType, ValueType> = (source: SourceType) => Promise<ValueType>;
 
-// These effectively do what `const enum` does, but doing it manually so we are not coupled to
-// use `tsc` itself to build them. Additionally, though, we only allocate a single array per
-// `Resource`, and reuse its memory when transitioning states. It would be nice if we could
-// make *that* operation safe, but at least this way it is isolated to these "constructors"
-// and the usage can be type safe.
-const INITIAL_TAG = 0;
-const LOADING_TAG = 1;
-const LOADED_TAG = 2;
-const ERROR_TAG = 3;
-
-type Initial = [typeof INITIAL_TAG];
-const Initial = (): Initial => [INITIAL_TAG];
-
-type Loading = [typeof LOADING_TAG];
-const Loading = <T>(state: State<T>): Loading => {
-  state[0] = LOADING_TAG;
-  state[1] = undefined;
-  return state as Loading;
-};
-
-type Loaded<T> = [typeof LOADED_TAG, T];
-const Loaded = <T>(state: State<T>, value: T): Loaded<T> => {
-  state[0] = LOADED_TAG;
-  state[1] = value;
-  return state as Loaded<T>;
-};
-
-type Failed = [typeof ERROR_TAG, unknown];
-const Failed = <T>(state: State<T>, err: unknown): Failed => {
-  state[0] = ERROR_TAG;
-  state[1] = err;
-  return state as Failed;
-};
-
-type State<T> = Initial | Loading | Loaded<T> | Failed;
-
 export class Resource<ValueType> {
   private fetcher: Fetcher<ValueType>;
   private tag = createTag();
-  private state = createSignal<State<ValueType>>(
-    Initial(),
-    ([oldState], [newState]) => oldState !== newState
-  );
-
-  get loading(): boolean {
-    return this.state.value[0] === LOADING_TAG;
-  }
-
-  get error(): unknown {
-    // The check is important so we never return the value for a loaded case!
-    return this.state.value[0] === ERROR_TAG ? this.state.value[1] : undefined;
-  }
+  loading = createSignal(false);
+  error: Signal<unknown> = createSignal();
 
   last?: ValueType | undefined;
 
-  get current(): ValueType | undefined {
-    return this.state.value[0] === LOADED_TAG ? this.state.value[1] : undefined;
-  }
+  current?: ValueType | undefined;
 
   constructor(fetcher: Fetcher<ValueType>) {
     this.fetcher = fetcher;
@@ -71,18 +22,19 @@ export class Resource<ValueType> {
   }
 
   private async fetch() {
-    this.state.value = Loading(this.state.value);
+    this.loading.value = true;
 
     try {
       // We always want to go ahead and update the previous state, so that we always end up
       // with both the previous result (if any) *and* the new value *or* error, and never
       // end up just throwing away data.
       this.last = this.current;
-      const value = await this.fetcher(true);
-      this.state.value = Loaded(this.state.value, value);
+      this.current = await this.fetcher(true);
       markUpdate(this.tag);
     } catch (err: unknown) {
-      this.state.value = Failed(this.state.value, err);
+      this.error.value = err;
+    } finally {
+      this.loading.value = false;
     }
   }
 
@@ -95,25 +47,11 @@ export class Resource<ValueType> {
 export class ResourceWithSignal<ValueType, SourceType> {
   private fetcher: FetcherWithSource<SourceType, ValueType>;
   private tag = createTag();
-  private state = createSignal<State<ValueType>>(
-    Initial(),
-    ([oldState], [newState]) => oldState !== newState
-  );
-
-  get loading(): boolean {
-    return this.state.value[0] === LOADING_TAG;
-  }
-
-  get error(): unknown {
-    // The check is important so we never return the value for a loaded case!
-    return this.state.value[0] === ERROR_TAG ? this.state.value[1] : undefined;
-  }
+  loading = createSignal(false);
+  error: Signal<unknown> = createSignal();
 
   last?: ValueType | undefined;
-
-  get current(): ValueType | undefined {
-    return this.state.value[0] === LOADED_TAG ? this.state.value[1] : undefined;
-  }
+  current?: ValueType | undefined;
 
   constructor(
     source: ReactiveValue<SourceType>,
@@ -123,7 +61,6 @@ export class ResourceWithSignal<ValueType, SourceType> {
     createEffect(() => {
       const value = source.value;
       if (value === false || value === null || value === undefined) {
-        console.log('bail!');
         return;
       }
       this.fetch(value);
@@ -131,18 +68,19 @@ export class ResourceWithSignal<ValueType, SourceType> {
   }
 
   private async fetch(source: SourceType) {
-    this.state.value = Loading(this.state.value);
+    this.loading.value = true;
 
     try {
       // We always want to go ahead and update the previous state, so that we always end up
       // with both the previous result (if any) *and* the new value *or* error, and never
       // end up just throwing away data.
       this.last = this.current;
-      const value = await this.fetcher(source);
-      this.state.value = Loaded(this.state.value, value);
+      this.current = await this.fetcher(source);
       markUpdate(this.tag);
     } catch (err) {
-      this.state.value = Failed(this.state.value, err);
+      this.error.value = err;
+    } finally {
+      this.loading.value = false;
     }
   }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -64,7 +64,11 @@ class ResourceWithSignal<ValueType, SourceType> {
     this.source = source;
     this.tag = createTag();
     createEffect(() => {
-      this.fetch(this.source.value);
+      const value = this.source.value;
+      if (value === false || value === null || value === undefined) {
+        return;
+      }
+      this.fetch(value);
     }, [this.source]);
   }
 

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -50,16 +50,18 @@ export class Signal<T> {
   }
 }
 
-export function createSignal(value?: null | undefined): Signal<unknown>;
-export function createSignal<T extends {}>(value: T, isEqual?: Equality<T> | false): Signal<T>;
+export function createSignal(): Signal<unknown>;
+export function createSignal<T>(value: T, isEqual?: Equality<T> | false): Signal<T>;
 export function createSignal<T extends {}>(
-  value?: T | null | undefined,
+  value?: T,
   isEqual?: Equality<T> | false
 ): Signal<T> | Signal<unknown> {
-  if (value == null) {
-    // SAFETY: this is legal, because we are *widening* the type to a safe "top" type.
-    return new Signal(null as unknown);
+  if (arguments.length === 0) {
+    return new Signal(null as unknown, false);
+  } else {
+    // SAFETY: TS doesn't understand that the `arguments` check means there is
+    // always *something* passed as `value` here, and therefore that it is safe
+    // to treat `value` as indicating what `T` must be.
+    return new Signal(value as T, isEqual);
   }
-
-  return new Signal(value, isEqual);
 }

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -51,11 +51,8 @@ export class Signal<T> {
 }
 
 export function createSignal(value?: null | undefined): Signal<null>;
-export function createSignal<T extends NonNullable<unknown>>(
-  value: T,
-  isEqual?: Equality<T> | false
-): Signal<T>;
-export function createSignal<T extends NonNullable<unknown>>(
+export function createSignal<T extends {}>(value: T, isEqual?: Equality<T> | false): Signal<T>;
+export function createSignal<T extends {}>(
   value?: T | null | undefined,
   isEqual?: Equality<T> | false
 ): Signal<T> | Signal<null> {

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -50,14 +50,15 @@ export class Signal<T> {
   }
 }
 
-export function createSignal(value?: null | undefined): Signal<null>;
+export function createSignal(value?: null | undefined): Signal<unknown>;
 export function createSignal<T extends {}>(value: T, isEqual?: Equality<T> | false): Signal<T>;
 export function createSignal<T extends {}>(
   value?: T | null | undefined,
   isEqual?: Equality<T> | false
-): Signal<T> | Signal<null> {
+): Signal<T> | Signal<unknown> {
   if (value == null) {
-    return new Signal(null);
+    // SAFETY: this is legal, because we are *widening* the type to a safe "top" type.
+    return new Signal(null as unknown);
   }
 
   return new Signal(value, isEqual);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+import type { Derived } from './derived';
+import type { Signal } from './signal';
+
+export type ReactiveValue<T> = Signal<T> | Derived<T>;

--- a/tests/resource.spec.ts
+++ b/tests/resource.spec.ts
@@ -1,7 +1,7 @@
 import defer from 'p-defer';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, expectTypeOf, test, vi } from 'vitest';
 import { createEffect, createSignal } from '../src';
-import { createResource } from '../src/resource';
+import { createResource, type Resource } from '../src/resource';
 
 describe('Resource', () => {
   describe('without source', () => {
@@ -9,7 +9,8 @@ describe('Resource', () => {
       const deferred = defer<string>();
       const resourceSpy = vi.fn(() => deferred.promise);
 
-      const resource = createResource<string>(resourceSpy);
+      const resource = createResource(resourceSpy);
+      expectTypeOf(resource).toEqualTypeOf<Resource<string>>();
 
       let message: string | undefined = '';
 
@@ -21,7 +22,7 @@ describe('Resource', () => {
 
       expect(message).toEqual(undefined);
 
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
 
       deferred.resolve('foo');
 
@@ -32,7 +33,7 @@ describe('Resource', () => {
       expect(effectSpy).toHaveBeenCalledTimes(2);
       expect(message).toEqual('foo');
 
-      expect(resource.loading.value).toBe(false);
+      expect(resource.loading).toBe(false);
     });
 
     test('with error', async () => {
@@ -41,13 +42,13 @@ describe('Resource', () => {
 
       const resource = createResource(resourceSpy);
 
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
 
       d.reject('error');
 
       await expect(d.promise).rejects.toThrow('error');
-      expect(resource.error?.value).toEqual('error');
-      expect(resource.loading.value).toBe(false);
+      expect(resource.error).toEqual('error');
+      expect(resource.loading).toBe(false);
     });
   });
 
@@ -73,7 +74,7 @@ describe('Resource', () => {
 
       expect(message).toEqual(undefined);
 
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
       deferred.resolve(0);
 
       await expect(deferred.promise).resolves.toEqual(0);
@@ -90,7 +91,7 @@ describe('Resource', () => {
     });
 
     test('it does not run when source is null, false, or undefined', async () => {
-      const source = createSignal<any>(null);
+      const source = createSignal(null);
       const deferred = defer<number>();
 
       const resourceSpy = vi.fn(() => {
@@ -100,13 +101,13 @@ describe('Resource', () => {
       const resource = createResource(source, resourceSpy);
       // At this point, nothing should happen because the source is null
       expect(resourceSpy).not.toHaveBeenCalled();
-      expect(resource.loading.value).toBe(false);
+      expect(resource.loading).toBe(false);
 
       source.value = 1;
 
       // Now that we've set the value to something eligible for a run, everything should suddenly
       // start running
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
       expect(resourceSpy).toHaveBeenCalledOnce();
       expect(resourceSpy).toHaveBeenLastCalledWith(1);
       deferred.resolve(0);
@@ -116,7 +117,7 @@ describe('Resource', () => {
 
       // updating the source to another ineligible value should not change anything, all the
       // prior assertions should still pass
-      expect(resource.loading.value).toBe(false);
+      expect(resource.loading).toBe(false);
       expect(resourceSpy).toHaveBeenCalledOnce();
       expect(resourceSpy).toHaveBeenLastCalledWith(1);
     });

--- a/tests/resource.spec.ts
+++ b/tests/resource.spec.ts
@@ -1,0 +1,91 @@
+import defer from 'p-defer';
+import { describe, expect, test, vi } from 'vitest';
+import { createEffect, createSignal } from '../src';
+import { createResource } from '../src/resource';
+
+describe('Resource', () => {
+  describe('without source', () => {
+    test('it works', async () => {
+      const deferred = defer<string>();
+      const resourceSpy = vi.fn(() => deferred.promise);
+
+      const resource = createResource<string>(resourceSpy);
+
+      let message: string | undefined = '';
+
+      const effectSpy = vi.fn(() => {
+        message = resource.value;
+      });
+
+      createEffect(effectSpy);
+
+      expect(message).toEqual(undefined);
+
+      expect(resource.loading.value).toBe(true);
+
+      deferred.resolve('foo');
+
+      expect(effectSpy).toHaveBeenCalledOnce();
+
+      await expect(deferred.promise).resolves.toEqual('foo');
+
+      expect(effectSpy).toHaveBeenCalledTimes(2);
+      expect(message).toEqual('foo');
+
+      expect(resource.loading.value).toBe(false);
+    });
+
+    test('with error', async () => {
+      const d = defer();
+      const resourceSpy = vi.fn(() => d.promise);
+
+      const resource = createResource(resourceSpy);
+
+      expect(resource.loading.value).toBe(true);
+
+      d.reject('error');
+
+      await expect(d.promise).rejects.toThrow('error');
+      expect(resource.error).toEqual('error');
+      expect(resource.loading.value).toBe(false);
+    });
+  });
+
+  describe('with source', () => {
+    test('it works', async () => {
+      const source = createSignal(0);
+      const deferred = defer<number>();
+
+      const resourceSpy = vi.fn(() => {
+        return deferred.promise;
+      });
+
+      const resource = createResource(source, resourceSpy);
+
+      let message: number | undefined;
+
+      const effectSpy = vi.fn(() => {
+        message = resource.value;
+      });
+
+      createEffect(effectSpy);
+
+      expect(message).toEqual(undefined);
+
+      expect(resource.loading.value).toBe(true);
+      deferred.resolve(0);
+
+      await expect(deferred.promise).resolves.toEqual(0);
+
+      expect(resourceSpy).toHaveBeenLastCalledWith(0);
+      expect(resourceSpy).toHaveBeenCalledOnce();
+      source.value = 1;
+      expect(resourceSpy).toHaveBeenCalledTimes(2);
+      expect(resourceSpy).toHaveBeenLastCalledWith(1);
+
+      source.value = 2;
+      expect(resourceSpy).toHaveBeenCalledTimes(3);
+      expect(resourceSpy).toHaveBeenLastCalledWith(2);
+    });
+  });
+});

--- a/tests/resource.spec.ts
+++ b/tests/resource.spec.ts
@@ -46,7 +46,7 @@ describe('Resource', () => {
       d.reject('error');
 
       await expect(d.promise).rejects.toThrow('error');
-      expect(resource.error).toEqual('error');
+      expect(resource.error?.value).toEqual('error');
       expect(resource.loading.value).toBe(false);
     });
   });


### PR DESCRIPTION
Adding `createResource` that is *heavily* inspired by [the Solid.js version](https://www.solidjs.com/docs/latest/api#createresource), but exposed a singular reactive value rather than the getter/setter approach they use.

Right now, you can:

- create resources with or with out a source signal
  - with no source signal, the resource will run the async request one time and expose a `loading` signal and an `error` signal
  - with a source signal, the resource will run the async request immediately, passing the source value to the fetcher, and will then re-run the fetcher whenever the source signal changes

Still need to implement:

- [ ] manual refetch (this could be *dead* simple but i have a gut feeling that there's something weird here)
- [ ] better state indication (loading, pending, refreshing, etc.)