### PR TITLE
Resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.tsbuildinfo

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -8,14 +8,10 @@ export class Effect {
   #computeFn: ComputeFn;
   #version: number;
   #prevTags?: Array<Tag>;
-  // I would like to *not* use `any` here, but it could *actually* be anything so i'm not sure
-  // if there's a better option
-  // TODO: use something better than any here
-  #deps?: Array<ReactiveValue<any>> | undefined;
+  #deps?: Array<ReactiveValue<unknown>> | undefined;
   #cleanupFn?: () => void;
 
-  // TODO: use something better than any here
-  constructor(fn: ComputeFn, deps?: Array<ReactiveValue<any>>) {
+  constructor(fn: ComputeFn, deps?: Array<ReactiveValue<unknown>>) {
     this.#computeFn = fn;
     this.#version = MANAGER.version;
     this.#deps = deps;

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,40 +1,85 @@
 import { createEffect } from './effect';
-import { createSignal, type Signal } from './signal';
-import { createTag, markDependency, markUpdate, type Tag } from './tag';
+import { createSignal } from './signal';
+import { createTag, markDependency, markUpdate } from './tag';
 import type { ReactiveValue } from './types';
 
 type Fetcher<ValueType> = (source: true) => Promise<ValueType>;
 type FetcherWithSource<SourceType, ValueType> = (source: SourceType) => Promise<ValueType>;
 
+// These effectively do what `const enum` does, but doing it manually so we are not coupled to
+// use `tsc` itself to build them. Additionally, though, we only allocate a single array per
+// `Resource`, and reuse its memory when transitioning states. It would be nice if we could
+// make *that* operation safe, but at least this way it is isolated to these "constructors"
+// and the usage can be type safe.
+const INITIAL_TAG = 0;
+const LOADING_TAG = 1;
+const LOADED_TAG = 2;
+const ERROR_TAG = 3;
+
+type Initial = [typeof INITIAL_TAG];
+const Initial = (): Initial => [INITIAL_TAG];
+
+type Loading = [typeof LOADING_TAG];
+const Loading = <T>(state: State<T>): Loading => {
+  state[0] = LOADING_TAG;
+  state[1] = undefined;
+  return state as Loading;
+};
+
+type Loaded<T> = [typeof LOADED_TAG, T];
+const Loaded = <T>(state: State<T>, value: T): Loaded<T> => {
+  state[0] = LOADED_TAG;
+  state[1] = value;
+  return state as Loaded<T>;
+};
+
+type Failed = [typeof ERROR_TAG, unknown];
+const Failed = <T>(state: State<T>, err: unknown): Failed => {
+  state[0] = ERROR_TAG;
+  state[1] = err;
+  return state as Failed;
+};
+
+type State<T> = Initial | Loading | Loaded<T> | Failed;
+
 export class Resource<ValueType> {
   private fetcher: Fetcher<ValueType>;
-  private tag: Tag;
-  loading = createSignal(false);
-  error: Signal<any> = createSignal();
+  private tag = createTag();
+  private state = createSignal<State<ValueType>>(Initial());
+
+  get loading(): boolean {
+    return this.state.value[0] === LOADING_TAG;
+  }
+
+  get error(): unknown {
+    // The check is important so we never return the value for a loaded case!
+    return this.state.value[0] === ERROR_TAG ? this.state.value[1] : undefined;
+  }
 
   last?: ValueType | undefined;
 
-  current?: ValueType | undefined;
+  get current(): ValueType | undefined {
+    return this.state.value[0] === LOADED_TAG ? this.state.value[1] : undefined;
+  }
 
   constructor(fetcher: Fetcher<ValueType>) {
     this.fetcher = fetcher;
-
-    this.tag = createTag();
-
     this.fetch();
   }
 
   private async fetch() {
-    this.loading.value = true;
+    this.state.value = Loading(this.state.value);
 
     try {
+      // We always want to go ahead and update the previous state, so that we always end up
+      // with both the previous result (if any) *and* the new value *or* error, and never
+      // end up just throwing away data.
       this.last = this.current;
-      this.current = await this.fetcher(true);
+      const value = await this.fetcher(true);
+      this.state.value = Loaded(this.state.value, value);
       markUpdate(this.tag);
-    } catch (err: any) {
-      this.error.value = err;
-    } finally {
-      this.loading.value = false;
+    } catch (err: unknown) {
+      this.state.value = Failed(this.state.value, err);
     }
   }
 
@@ -46,42 +91,52 @@ export class Resource<ValueType> {
 
 export class ResourceWithSignal<ValueType, SourceType> {
   private fetcher: FetcherWithSource<SourceType, ValueType>;
-  private source: ReactiveValue<SourceType>;
-  private tag: Tag;
-  loading = createSignal(false);
-  error: Signal<any> = createSignal();
+  private tag = createTag();
+  private state = createSignal<State<ValueType>>(Initial());
+
+  get loading(): boolean {
+    return this.state.value[0] === LOADING_TAG;
+  }
+
+  get error(): unknown {
+    // The check is important so we never return the value for a loaded case!
+    return this.state.value[0] === ERROR_TAG ? this.state.value[1] : undefined;
+  }
 
   last?: ValueType | undefined;
 
-  current?: ValueType | undefined;
+  get current(): ValueType | undefined {
+    return this.state.value[0] === LOADED_TAG ? this.state.value[1] : undefined;
+  }
 
   constructor(
     source: ReactiveValue<SourceType>,
     fetcher: FetcherWithSource<SourceType, ValueType>
   ) {
     this.fetcher = fetcher;
-    this.source = source;
-    this.tag = createTag();
     createEffect(() => {
-      const value = this.source.value;
+      const value = source.value;
       if (value === false || value === null || value === undefined) {
+        console.log('bail!');
         return;
       }
       this.fetch(value);
-    }, [this.source]);
+    }, [source]);
   }
 
   private async fetch(source: SourceType) {
-    this.loading.value = true;
+    this.state.value = Loading(this.state.value);
 
     try {
+      // We always want to go ahead and update the previous state, so that we always end up
+      // with both the previous result (if any) *and* the new value *or* error, and never
+      // end up just throwing away data.
       this.last = this.current;
-      this.current = await this.fetcher(source);
+      const value = await this.fetcher(source);
+      this.state.value = Loaded(this.state.value, value);
       markUpdate(this.tag);
     } catch (err) {
-      this.error.value = err;
-    } finally {
-      this.loading.value = false;
+      this.state.value = Failed(this.state.value, err);
     }
   }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -45,7 +45,10 @@ type State<T> = Initial | Loading | Loaded<T> | Failed;
 export class Resource<ValueType> {
   private fetcher: Fetcher<ValueType>;
   private tag = createTag();
-  private state = createSignal<State<ValueType>>(Initial());
+  private state = createSignal<State<ValueType>>(
+    Initial(),
+    ([oldState], [newState]) => oldState !== newState
+  );
 
   get loading(): boolean {
     return this.state.value[0] === LOADING_TAG;
@@ -92,7 +95,10 @@ export class Resource<ValueType> {
 export class ResourceWithSignal<ValueType, SourceType> {
   private fetcher: FetcherWithSource<SourceType, ValueType>;
   private tag = createTag();
-  private state = createSignal<State<ValueType>>(Initial());
+  private state = createSignal<State<ValueType>>(
+    Initial(),
+    ([oldState], [newState]) => oldState !== newState
+  );
 
   get loading(): boolean {
     return this.state.value[0] === LOADING_TAG;

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -50,14 +50,15 @@ export class Signal<T> {
   }
 }
 
-export function createSignal(value?: null | undefined): Signal<null>;
+export function createSignal(value?: null | undefined): Signal<unknown>;
 export function createSignal<T extends {}>(value: T, isEqual?: Equality<T> | false): Signal<T>;
 export function createSignal<T extends {}>(
   value?: T | null | undefined,
   isEqual?: Equality<T> | false
-): Signal<T> | Signal<null> {
+): Signal<T> | Signal<unknown> {
   if (value == null) {
-    return new Signal(null);
+    // SAFETY: this is legal, because we are *widening* the type to a safe "top" type.
+    return new Signal(null as unknown);
   }
 
   return new Signal(value, isEqual);

--- a/tests/resource.spec.ts
+++ b/tests/resource.spec.ts
@@ -1,7 +1,7 @@
 import defer from 'p-defer';
-import { describe, expect, test, vi } from 'vitest';
+import { describe, expect, expectTypeOf, test, vi } from 'vitest';
 import { createEffect, createSignal } from '../src';
-import { createResource } from '../src/resource';
+import { createResource, type Resource } from '../src/resource';
 
 describe('Resource', () => {
   describe('without source', () => {
@@ -9,7 +9,8 @@ describe('Resource', () => {
       const deferred = defer<string>();
       const resourceSpy = vi.fn(() => deferred.promise);
 
-      const resource = createResource<string>(resourceSpy);
+      const resource = createResource(resourceSpy);
+      expectTypeOf(resource).toEqualTypeOf<Resource<string>>();
 
       let message: string | undefined = '';
 
@@ -21,7 +22,7 @@ describe('Resource', () => {
 
       expect(message).toEqual(undefined);
 
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
 
       deferred.resolve('foo');
 
@@ -32,7 +33,7 @@ describe('Resource', () => {
       expect(effectSpy).toHaveBeenCalledTimes(2);
       expect(message).toEqual('foo');
 
-      expect(resource.loading.value).toBe(false);
+      expect(resource.loading).toBe(false);
     });
 
     test('with error', async () => {
@@ -41,13 +42,13 @@ describe('Resource', () => {
 
       const resource = createResource(resourceSpy);
 
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
 
       d.reject('error');
 
       await expect(d.promise).rejects.toThrow('error');
-      expect(resource.error?.value).toEqual('error');
-      expect(resource.loading.value).toBe(false);
+      expect(resource.error).toEqual('error');
+      expect(resource.loading).toBe(false);
     });
   });
 
@@ -73,7 +74,7 @@ describe('Resource', () => {
 
       expect(message).toEqual(undefined);
 
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
       deferred.resolve(0);
 
       await expect(deferred.promise).resolves.toEqual(0);
@@ -90,7 +91,7 @@ describe('Resource', () => {
     });
 
     test('it does not run when source is null, false, or undefined', async () => {
-      const source = createSignal<any>(null);
+      const source = createSignal(null);
       const deferred = defer<number>();
 
       const resourceSpy = vi.fn(() => {
@@ -100,13 +101,13 @@ describe('Resource', () => {
       const resource = createResource(source, resourceSpy);
       // At this point, nothing should happen because the source is null
       expect(resourceSpy).not.toHaveBeenCalled();
-      expect(resource.loading.value).toBe(false);
+      expect(resource.loading).toBe(false);
 
       source.value = 1;
 
       // Now that we've set the value to something eligible for a run, everything should suddenly
       // start running
-      expect(resource.loading.value).toBe(true);
+      expect(resource.loading).toBe(true);
       expect(resourceSpy).toHaveBeenCalledOnce();
       expect(resourceSpy).toHaveBeenLastCalledWith(1);
       deferred.resolve(0);
@@ -116,7 +117,7 @@ describe('Resource', () => {
 
       // updating the source to another ineligible value should not change anything, all the
       // prior assertions should still pass
-      expect(resource.loading.value).toBe(false);
+      expect(resource.loading).toBe(false);
       expect(resourceSpy).toHaveBeenCalledOnce();
       expect(resourceSpy).toHaveBeenLastCalledWith(1);
     });


### PR DESCRIPTION
This takes the existing base PR and improves type safety a bit as well as *hopefully* improves performance: it switches from having two `Signal` allocations (one each for `loading` and `error`) on a `Resource` to having a single `Signal` per `Resource`, representing its whole state, and using an `Array` type as a tuple to represent that state—rewriting the contents of the tuple to avoid re-allocating it.

---

This replaces #5 and #6. (Lulz.)