### PR TITLE
Performance tweaks

### DIFF
--- a/src/derived.ts
+++ b/src/derived.ts
@@ -42,7 +42,7 @@ export class Derived<T> {
       return this.prevResult as T;
     }
 
-    const prevCompute = MANAGER.currentContext;
+    const prevContext = MANAGER.currentContext;
 
     const context = MANAGER.fetchContext(this);
     context.clear();
@@ -76,14 +76,14 @@ export class Derived<T> {
       // we're in the middle of an effect computation, we add that derived value's dependencies as
       // direct dependencies on the effect. That way the effect will know to recompute even if
       // the derived value itself hasn't been re-run and marked as updated
-      if (MANAGER.runningEffect && prevCompute) {
+      if (MANAGER.runningEffect && prevContext) {
         // If the effect has specified its own dependencies, then we want to skip this so we don't
         // add extra dependencies to the effect
         if (!MANAGER.runningEffect.hasDeps) {
           MANAGER.currentContext.forEach((c) => {
             // We definitely know prevCompute is defined already but TS does not agree since we're
             // in a callback here, so adding the extra assertion just to be thorough
-            prevCompute && prevCompute.add(c);
+            prevContext && prevContext.add(c);
           });
         }
       }
@@ -92,7 +92,7 @@ export class Derived<T> {
         markUpdate(this.tag);
       }
 
-      MANAGER.currentContext = prevCompute;
+      MANAGER.currentContext = prevContext;
     }
 
     return this.prevResult;

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -34,7 +34,7 @@ export class Effect {
   }
 
   compute(): (() => void) | void {
-    const prevCompute = MANAGER.currentContext;
+    const prevContext = MANAGER.currentContext;
 
     const context = MANAGER.fetchContext(this);
     context.clear();

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -46,7 +46,7 @@ export class Effect {
 
     if (this.#prevTags && getMax(this.#prevTags) === this.#version) {
       MANAGER.runningEffect = null;
-      MANAGER.currentContext = prevCompute;
+      MANAGER.currentContext = prevContext;
       return;
     }
 
@@ -58,7 +58,7 @@ export class Effect {
       this.#prevTags = Array.from(MANAGER.currentContext);
       this.#version = getMax(this.#prevTags);
 
-      MANAGER.currentContext = prevCompute;
+      MANAGER.currentContext = prevContext;
       MANAGER.runningEffect = null;
     }
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,13 +1,17 @@
+import type { Derived } from './derived';
 import type { Effect } from './effect';
 import type { Tag } from './tag';
 
 class Manager {
   #version = 0;
+
   batchCount = 0;
-  batchIteration = 0;
-  currentCompute: Set<Tag> | null = null;
-  runningEffect: Effect | null = null;
+
+  contexts = new WeakMap<Derived<unknown> | Effect, Set<Tag>>();
+  currentContext: Set<Tag> | null = null;
+
   effects = new Set<Effect>();
+  runningEffect: Effect | null = null;
 
   get isEffectRunning(): boolean {
     return !!this.runningEffect;
@@ -36,6 +40,17 @@ class Manager {
     this.effects.forEach((effect) => {
       effect.compute();
     });
+  }
+
+  fetchContext(k: Derived<unknown> | Effect): Set<Tag> {
+    let context = this.contexts.get(k);
+
+    if (!context) {
+      context = new Set<Tag>();
+      this.contexts.set(k, context);
+    }
+
+    return context;
   }
 }
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -13,13 +13,13 @@ export function createTag(): Tag {
 }
 
 export function markDependency(t: Tag): void {
-  if (MANAGER.currentCompute) {
-    MANAGER.currentCompute.add(t);
+  if (MANAGER.currentContext) {
+    MANAGER.currentContext.add(t);
   }
 }
 
 export function markUpdate(t: Tag): void {
-  if (MANAGER.currentCompute?.has(t)) {
+  if (MANAGER.currentContext?.has(t)) {
     throw new Error('Cannot update a tag that has been used during a computation.');
   }
 


### PR DESCRIPTION
After talking with @chriskrycho we realized that two big opportunities to improve performance were to remove all of the native private fields (because they transpile to something miserable) and to find a way to avoid allocating a new `Set` every time a `Derived` or `Effect` computes.

This PR represents the first attempt at controlling our Set allocations by allocating a single Set per reactive value, and then storing and re-using it in a `WeakMap` on the `Manager` instance. Now, instead of creating a new `Set` every time we begin a new computation, we instead get (or create) the compute context for that value out of the Manager's `WeakMap`, clear it, and set it as the current context.