### PR TITLE
Inline the `Tag` type onto `Signal` and `Derived`

### DIFF
--- a/src/derived.ts
+++ b/src/derived.ts
@@ -1,4 +1,4 @@
-import { markDependency, markUpdate, getMax, Tag, createTag } from './tag';
+import { markDependency, markUpdate, getMax, createTag, REVISION, Tagged } from './tag';
 import {
   addTagToCurrentContext,
   setupCurrentContext,
@@ -9,18 +9,16 @@ import {
   setCurrentContext,
 } from './state';
 
-class Derived<T> {
+class Derived<T> implements Tagged {
   private computeFn: () => T;
-  private version: number;
+  private version = getVersion();
   private prevResult?: T;
-  private prevTags?: Array<Tag>;
+  private prevTags?: Array<Tagged>;
 
-  private tag: Tag;
+  [REVISION] = createTag();
 
   constructor(compute: () => T) {
     this.computeFn = compute;
-    this.version = getVersion();
-    this.tag = createTag();
 
     // Access the value immediately so we can cache the result and get reference to all the
     // dependent values
@@ -30,7 +28,7 @@ class Derived<T> {
   get value(): T {
     // No matter what, we call `markDependency` immediately so that this derived value gets
     // identified as a dependency of whoever accessed it no matter what
-    markDependency(this.tag);
+    markDependency(this);
 
     const prevContext = getCurrentContext();
 
@@ -95,7 +93,7 @@ class Derived<T> {
       }
 
       if (shouldMarkUpdate) {
-        markUpdate(this.tag);
+        markUpdate(this);
       }
 
       setCurrentContext(prevContext);

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -7,7 +7,7 @@ import {
   setCurrentContext,
   removeEffect,
 } from './state';
-import { getMax, Tag } from './tag';
+import { getMax, Tagged } from './tag';
 import type { ReactiveValue } from './types';
 
 type ComputeFn = () => void | (() => void);
@@ -15,7 +15,7 @@ type ComputeFn = () => void | (() => void);
 class Effect {
   private _computeFn: ComputeFn;
   private _version: number;
-  private _prevTags?: Array<Tag>;
+  private _prevTags?: Array<Tagged>;
   private _deps?: Array<ReactiveValue<unknown>> | undefined;
   private _cleanupFn?: () => void;
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -1,14 +1,14 @@
 import { createEffect } from './effect';
 import { createSignal, Signal } from './signal';
-import { createTag, markDependency, markUpdate } from './tag';
+import { createTag, markDependency, markUpdate, REVISION, Tagged } from './tag';
 import type { ReactiveValue } from './types';
 
 type Fetcher<ValueType> = (source: true) => Promise<ValueType>;
 type FetcherWithSource<SourceType, ValueType> = (source: SourceType) => Promise<ValueType>;
 
-export class Resource<ValueType> {
+export class Resource<ValueType> implements Tagged {
   private fetcher: Fetcher<ValueType>;
-  private tag = createTag();
+  [REVISION] = createTag();
   loading = createSignal(false);
   error: Signal<unknown> = createSignal();
 
@@ -30,7 +30,7 @@ export class Resource<ValueType> {
       // end up just throwing away data.
       this.last = this.current;
       this.current = await this.fetcher(true);
-      markUpdate(this.tag);
+      markUpdate(this);
     } catch (err: unknown) {
       this.error.value = err;
     } finally {
@@ -39,14 +39,14 @@ export class Resource<ValueType> {
   }
 
   get value() {
-    markDependency(this.tag);
+    markDependency(this);
     return this.current;
   }
 }
 
-export class ResourceWithSignal<ValueType, SourceType> {
+export class ResourceWithSignal<ValueType, SourceType> implements Tagged {
   private fetcher: FetcherWithSource<SourceType, ValueType>;
-  private tag = createTag();
+  [REVISION] = createTag();
   loading = createSignal(false);
   error: Signal<unknown> = createSignal();
 
@@ -76,7 +76,7 @@ export class ResourceWithSignal<ValueType, SourceType> {
       // end up just throwing away data.
       this.last = this.current;
       this.current = await this.fetcher(source);
-      markUpdate(this.tag);
+      markUpdate(this);
     } catch (err) {
       this.error.value = err;
     } finally {
@@ -85,7 +85,7 @@ export class ResourceWithSignal<ValueType, SourceType> {
   }
 
   get value() {
-    markDependency(this.tag);
+    markDependency(this);
     return this.current;
   }
 }

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -1,4 +1,4 @@
-import { createTag, markDependency, markUpdate, type Tag } from './tag';
+import { createTag, markDependency, markUpdate, REVISION, Tagged } from './tag';
 
 type Equality<T> = (oldValue: T, newValue: T) => boolean;
 
@@ -16,10 +16,11 @@ function neverEqual(): boolean {
  */
 export const Peek = Symbol('Peek');
 
-class _Signal<T> {
+class _Signal<T> implements Tagged {
   private _value: T;
   private _isEqual: Equality<T>;
-  private _tag: Tag;
+
+  [REVISION] = createTag();
 
   constructor(value: T, isEqual: Equality<T> | false = baseEquality) {
     this._value = value;
@@ -29,18 +30,17 @@ class _Signal<T> {
     } else {
       this._isEqual = isEqual;
     }
-    this._tag = createTag();
   }
 
   get value(): T {
-    markDependency(this._tag);
+    markDependency(this);
     return this._value;
   }
 
   set value(v: T) {
     if (!this._isEqual(this._value, v)) {
       this._value = v;
-      markUpdate(this._tag);
+      markUpdate(this);
     }
   }
 

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -1,4 +1,4 @@
-import { createTag, markDependency, markUpdate, REVISION, Tagged } from './tag';
+import { createTag, markDependency, markUpdate, REVISION, type Tagged } from './tag';
 
 type Equality<T> = (oldValue: T, newValue: T) => boolean;
 


### PR DESCRIPTION
This keeps the same basic contract as we had previously, but it does it in a way which avoids allocating an extra `Tag` object for every single `Signal` or `Derived` instance. The idea is: introduce the revision count onto the items themselves, and define an interface which makes that contract explicit. Additionally, so that we don't accidentally compare *other* `number` values to tags, provide an opaque "new type" definition for `Tag`, which is only ever cast in the `tag` and `state` modules, so that consumers can treat it as a discrete type, but things like `Math.max` still work.

Net, this means we may keep around `Signal` and `Derived` one extra cycle in cases where they are dependencies of other `Derived` or `Effect` instances, but in exchange we get to avoid allocating fully half the objects we were allocating otherwise: even if small, that can add up when there are many of these.