### PR TITLE
Fix a variety of type issues

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -94,7 +94,7 @@ jobs:
         run: pnpm install
 
       - name: Install TypeScript ${{ matrix.ts-version }}
-        run: pnpm install --dev typescript@${{ matrix.ts-version }}
+        run: pnpm add --dev typescript@${{ matrix.ts-version }}
 
       - name: Type check
         run: pnpm tsc --noEmit

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -94,7 +94,7 @@ jobs:
         run: pnpm install
 
       - name: Install TypeScript ${{ matrix.ts-version }}
-        run: pnpm add --dev typescript@${{ matrix.ts-version }}
+        run: pnpm add --save-dev typescript@${{ matrix.ts-version }}
 
       - name: Type check
         run: pnpm tsc --noEmit

--- a/src/derived.ts
+++ b/src/derived.ts
@@ -9,7 +9,7 @@ import {
   setCurrentContext,
 } from './state';
 
-export class Derived<T> {
+class Derived<T> {
   private computeFn: () => T;
   private version: number;
   private prevResult?: T;
@@ -108,6 +108,8 @@ export class Derived<T> {
     throw new Error('derived values are readonly');
   }
 }
+
+export type { Derived };
 
 export function createDerived<T>(fn: () => T) {
   return new Derived(fn);

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -35,7 +35,7 @@ class Effect {
     return this._deps ? this._deps.length > 0 : false;
   }
 
-  _computeDeps(): void {
+  private _computeDeps(): void {
     if (this._deps) {
       this._deps.forEach((dep) => dep.value);
     }

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -12,32 +12,32 @@ import type { ReactiveValue } from './types';
 
 type ComputeFn = () => void | (() => void);
 
-export class Effect {
-  #computeFn: ComputeFn;
-  #version: number;
-  #prevTags?: Array<Tag>;
-  #deps?: Array<ReactiveValue<unknown>> | undefined;
-  #cleanupFn?: () => void;
+class Effect {
+  private _computeFn: ComputeFn;
+  private _version: number;
+  private _prevTags?: Array<Tag>;
+  private _deps?: Array<ReactiveValue<unknown>> | undefined;
+  private _cleanupFn?: () => void;
 
   constructor(fn: ComputeFn, deps?: Array<ReactiveValue<unknown>>) {
-    this.#computeFn = fn;
-    this.#version = getVersion();
-    this.#deps = deps;
+    this._computeFn = fn;
+    this._version = getVersion();
+    this._deps = deps;
     registerEffect(this);
     const maybeCleanupFn = this.compute();
 
     if (typeof maybeCleanupFn === 'function') {
-      this.#cleanupFn = maybeCleanupFn;
+      this._cleanupFn = maybeCleanupFn;
     }
   }
 
   get hasDeps(): boolean {
-    return this.#deps ? this.#deps.length > 0 : false;
+    return this._deps ? this._deps.length > 0 : false;
   }
 
-  #computeDeps(): void {
-    if (this.#deps) {
-      this.#deps.forEach((dep) => dep.value);
+  _computeDeps(): void {
+    if (this._deps) {
+      this._deps.forEach((dep) => dep.value);
     }
   }
 
@@ -48,9 +48,9 @@ export class Effect {
 
     setRunningEffect(this);
 
-    this.#computeDeps();
+    this._computeDeps();
 
-    if (this.#prevTags && getMax(this.#prevTags) === this.#version) {
+    if (this._prevTags && getMax(this._prevTags) === this._version) {
       setRunningEffect(null);
       setCurrentContext(prevContext);
       return;
@@ -59,10 +59,10 @@ export class Effect {
     let result: (() => void) | void;
 
     try {
-      result = this.#computeFn();
+      result = this._computeFn();
     } finally {
-      this.#prevTags = Array.from(currentContext);
-      this.#version = getMax(this.#prevTags);
+      this._prevTags = Array.from(currentContext);
+      this._version = getMax(this._prevTags);
 
       setCurrentContext(prevContext);
       setRunningEffect(null);
@@ -72,8 +72,8 @@ export class Effect {
   }
 
   dispose(): boolean {
-    if (this.#cleanupFn) {
-      this.#cleanupFn();
+    if (this._cleanupFn) {
+      this._cleanupFn();
     }
     return removeEffect(this);
   }

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -79,6 +79,8 @@ class Effect {
   }
 }
 
+export type { Effect };
+
 export function createEffect(fn: () => void, deps?: Array<ReactiveValue<unknown>>): () => boolean {
   const effect = new Effect(fn, deps);
   return effect.dispose.bind(effect);

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -6,6 +6,10 @@ function baseEquality<T>(oldValue: T, newValue: T) {
   return oldValue === newValue;
 }
 
+function neverEqual(): boolean {
+  return false;
+}
+
 /**
   @private This is available for internal "friend" APIs to use, but it is *not*
     legal to use by consumers.
@@ -21,7 +25,7 @@ export class Signal<T> {
     this.#value = value;
 
     if (isEqual === false) {
-      this.#isEqual = () => false;
+      this.#isEqual = neverEqual;
     } else {
       this.#isEqual = isEqual;
     }

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -17,30 +17,30 @@ function neverEqual(): boolean {
 export const Peek = Symbol('Peek');
 
 export class Signal<T> {
-  #value: T;
-  #isEqual: Equality<T>;
-  #tag: Tag;
+  private _value: T;
+  private _isEqual: Equality<T>;
+  private _tag: Tag;
 
   constructor(value: T, isEqual: Equality<T> | false = baseEquality) {
-    this.#value = value;
+    this._value = value;
 
     if (isEqual === false) {
-      this.#isEqual = neverEqual;
+      this._isEqual = neverEqual;
     } else {
-      this.#isEqual = isEqual;
+      this._isEqual = isEqual;
     }
-    this.#tag = createTag();
+    this._tag = createTag();
   }
 
   get value(): T {
-    markDependency(this.#tag);
-    return this.#value;
+    markDependency(this._tag);
+    return this._value;
   }
 
   set value(v: T) {
-    if (!this.#isEqual(this.#value, v)) {
-      this.#value = v;
-      markUpdate(this.#tag);
+    if (!this._isEqual(this._value, v)) {
+      this._value = v;
+      markUpdate(this._tag);
     }
   }
 
@@ -50,7 +50,7 @@ export class Signal<T> {
   // "peek", rather than using caching tools composed out of the core primitives, or to "be smarter"
   // than the signal system.)
   [Peek](): T {
-    return this.#value;
+    return this._value;
   }
 }
 


### PR DESCRIPTION
- For `Signal`, export only a type, not the full class, and exclude its private `_isEqual` property from the public type, which avoids a variance hazard (see 5e7c436 for more details).
- Only export the type sides of `Derived` and `Effect`
- Finish the switch-over  from `#` private to `private _` fields.